### PR TITLE
feat: 日報詳細画面とクリップボードコピー機能の実装

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -16,8 +16,10 @@
         "clsx": "^2.1.1",
         "lucide-react": "^0.562.0",
         "next": "16.1.1",
+        "next-themes": "^0.4.6",
         "react": "19.2.3",
         "react-dom": "19.2.3",
+        "sonner": "^2.0.7",
         "tailwind-merge": "^3.4.0"
       },
       "devDependencies": {
@@ -4916,6 +4918,16 @@
         }
       }
     },
+    "node_modules/next-themes": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.4.6.tgz",
+      "integrity": "sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc"
+      }
+    },
     "node_modules/next/node_modules/postcss": {
       "version": "8.4.31",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
@@ -5664,6 +5676,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/sonner": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/sonner/-/sonner-2.0.7.tgz",
+      "integrity": "sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
       }
     },
     "node_modules/source-map-js": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,8 +17,10 @@
     "clsx": "^2.1.1",
     "lucide-react": "^0.562.0",
     "next": "16.1.1",
+    "next-themes": "^0.4.6",
     "react": "19.2.3",
     "react-dom": "19.2.3",
+    "sonner": "^2.0.7",
     "tailwind-merge": "^3.4.0"
   },
   "devDependencies": {

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
+import { Toaster } from "@/components/ui/sonner";
 
 /**
  * グローバルフォント設定
@@ -39,6 +40,7 @@ export default function RootLayout({
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
         {children}
+        <Toaster />
       </body>
     </html>
   );

--- a/frontend/src/app/reports/[id]/page.tsx
+++ b/frontend/src/app/reports/[id]/page.tsx
@@ -1,0 +1,79 @@
+/* frontend/src/app/reports/id/page.tsx */
+import { createClient } from '@/utils/supabase/server'
+import { redirect, notFound } from 'next/navigation'
+import Link from 'next/link'
+import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
+import { ChevronLeft } from 'lucide-react'
+import { getReportById } from '@/services/reports'
+import { ReportCopySection } from '@/components/dashboard/ReportCopySection'
+
+type ReportDetailPageProps = {
+    params: Promise<{ id: string }>
+}
+
+/**
+ * 日報詳細ページ
+ * @param params パラメータ
+ * @returns 日報詳細ページ
+ */
+export default async function ReportDetailPage({ params }: ReportDetailPageProps) {
+    const supabase = await createClient()
+    const { data: { session } } = await supabase.auth.getSession()
+
+    if (!session) redirect('/login')
+
+    // パラメータを取得
+    const { id } = await params
+
+    // データを取得
+    const report = await getReportById(id, session.access_token)
+
+    // データが存在しない、または権限がない場合
+    if (!report) {
+        notFound() // 404ページを表示
+    }
+
+    return (
+        <div className="flex min-h-screen flex-col items-center p-8 bg-gray-50">
+            <div className="w-full max-w-3xl space-y-6">
+                {/* ヘッダーナビゲーション */}
+                <div className="flex items-center gap-4">
+                    <Link href="/">
+                        <Button variant="ghost" size="icon">
+                            <ChevronLeft className="h-5 w-5" />
+                        </Button>
+                    </Link>
+                    <h1 className="text-2xl font-bold text-gray-900 truncate">
+                        {report.subject || '日報詳細'}
+                    </h1>
+                </div>
+
+                {/* メタ情報 */}
+                <div className="flex items-center gap-4 text-sm text-gray-500 px-2">
+                    <p>{new Date(report.created_at).toLocaleString('ja-JP')}</p>
+                    <Badge variant="outline">
+                        丁寧度 Lv.{report.politeness_level}
+                    </Badge>
+                </div>
+
+                {/* 生成された日報（コピー機能付き） */}
+                <ReportCopySection
+                    title="生成された日報"
+                    content={report.content_polished}
+                />
+
+                {/* 元のメモ（参考用） */}
+                <div className="mt-8 pt-8 border-t">
+                    <h3 className="text-sm font-bold text-gray-700 mb-2">元の箇条書きメモ</h3>
+                    <div className="bg-white p-4 rounded-md border whitespace-pre-wrap text-gray-600 text-sm">
+                        {/* content_raw は APIのレスポンス型定義に追加が必要 */}
+                        {/* 一旦表示しないか、型定義を修正してから表示する */}
+                        (元のメモはまだ型定義に含まれていないため表示できません)
+                    </div>
+                </div>
+
+            </div>
+        </div>
+    )
+}

--- a/frontend/src/components/dashboard/ReportCopySection.tsx
+++ b/frontend/src/components/dashboard/ReportCopySection.tsx
@@ -1,0 +1,62 @@
+/* frontend/src/components/dashboard/ReportCopySection.tsx */
+'use client'
+
+import { useState } from 'react'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { toast } from 'sonner'
+import { Copy, Check } from 'lucide-react'
+
+type ReportCopySectionProps = {
+    title: string
+    content: string | null
+}
+
+/**
+ * 日報の内容をコピーするセクション
+ * @param title タイトル
+ * @param content コンテンツ
+ * @returns 日報の内容をコピーするセクション
+ */
+export function ReportCopySection({ title, content }: ReportCopySectionProps) {
+    const [copied, setCopied] = useState(false)
+    const textToCopy = content || ''
+
+    const handleCopy = async () => {
+        if (!textToCopy) return
+
+        try {
+            await navigator.clipboard.writeText(textToCopy)
+            setCopied(true)
+            toast.success('クリップボードにコピーしました')
+
+            // 2秒後にアイコンを戻す
+            setTimeout(() => setCopied(false), 2000)
+        } catch (err) {
+            toast.error('コピーに失敗しました')
+        }
+    }
+
+    return (
+        <Card className="relative">
+            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+                <CardTitle className="text-lg font-bold">{title}</CardTitle>
+                <Button
+                    variant="ghost"
+                    size="icon"
+                    onClick={handleCopy}
+                    disabled={!textToCopy}
+                    className="h-8 w-8"
+                >
+                    {copied ? <Check className="h-4 w-4" /> : <Copy className="h-4 w-4" />}
+                </Button>
+            </CardHeader>
+            <CardContent>
+                <div className="bg-gray-50 p-4 rounded-md whitespace-pre-wrap text-gray-800">
+                    {textToCopy || <span className="text-gray-400">（データなし）</span>}
+                </div>
+            </CardContent>
+        </Card>
+    )
+}
+

--- a/frontend/src/components/dashboard/ReportList.tsx
+++ b/frontend/src/components/dashboard/ReportList.tsx
@@ -1,4 +1,5 @@
 /* frontend/src/components/dashboard/ReportList.tsx */
+import Link from 'next/link'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
 import { Report } from '@/types' // Step 1で作った型
@@ -24,28 +25,30 @@ export function ReportList({ reports }: ReportListProps) {
             ) : (
                 <div className="grid gap-4">
                     {reports.map((report) => (
-                        <Card key={report.id} className="hover:shadow-md transition-shadow">
-                            <CardHeader className="pb-2">
-                                <div className="flex justify-between items-start">
-                                    <div className="space-y-1">
-                                        <CardTitle className="text-lg">
-                                            {report.subject || '（件名なし）'}
-                                        </CardTitle>
-                                        <p className="text-sm text-gray-500">
-                                            {new Date(report.created_at).toLocaleString('ja-JP')}
-                                        </p>
+                        <Link href={`/reports/${report.id}`} key={report.id}>
+                            <Card key={report.id} className="hover:shadow-md transition-shadow">
+                                <CardHeader className="pb-2">
+                                    <div className="flex justify-between items-start">
+                                        <div className="space-y-1">
+                                            <CardTitle className="text-lg">
+                                                {report.subject || '（件名なし）'}
+                                            </CardTitle>
+                                            <p className="text-sm text-gray-500">
+                                                {new Date(report.created_at).toLocaleString('ja-JP')}
+                                            </p>
+                                        </div>
+                                        <Badge variant={report.politeness_level >= 5 ? "default" : "secondary"}>
+                                            丁寧度 Lv.{report.politeness_level}
+                                        </Badge>
                                     </div>
-                                    <Badge variant={report.politeness_level >= 5 ? "default" : "secondary"}>
-                                        丁寧度 Lv.{report.politeness_level}
-                                    </Badge>
-                                </div>
-                            </CardHeader>
-                            <CardContent>
-                                <p className="text-sm text-gray-600 line-clamp-2">
-                                    {report.content_polished || '（生成中の可能性があります）'}
-                                </p>
-                            </CardContent>
-                        </Card>
+                                </CardHeader>
+                                <CardContent>
+                                    <p className="text-sm text-gray-600 line-clamp-2">
+                                        {report.content_polished || '（生成中の可能性があります）'}
+                                    </p>
+                                </CardContent>
+                            </Card>
+                        </Link>
                     ))}
                 </div>
             )}

--- a/frontend/src/components/ui/sonner.tsx
+++ b/frontend/src/components/ui/sonner.tsx
@@ -1,0 +1,40 @@
+"use client"
+
+import {
+  CircleCheckIcon,
+  InfoIcon,
+  Loader2Icon,
+  OctagonXIcon,
+  TriangleAlertIcon,
+} from "lucide-react"
+import { useTheme } from "next-themes"
+import { Toaster as Sonner, type ToasterProps } from "sonner"
+
+const Toaster = ({ ...props }: ToasterProps) => {
+  const { theme = "system" } = useTheme()
+
+  return (
+    <Sonner
+      theme={theme as ToasterProps["theme"]}
+      className="toaster group"
+      icons={{
+        success: <CircleCheckIcon className="size-4" />,
+        info: <InfoIcon className="size-4" />,
+        warning: <TriangleAlertIcon className="size-4" />,
+        error: <OctagonXIcon className="size-4" />,
+        loading: <Loader2Icon className="size-4 animate-spin" />,
+      }}
+      style={
+        {
+          "--normal-bg": "var(--popover)",
+          "--normal-text": "var(--popover-foreground)",
+          "--normal-border": "var(--border)",
+          "--border-radius": "var(--radius)",
+        } as React.CSSProperties
+      }
+      {...props}
+    />
+  )
+}
+
+export { Toaster }

--- a/frontend/src/services/reports.ts
+++ b/frontend/src/services/reports.ts
@@ -21,3 +21,30 @@ export async function getReports(accessToken: string): Promise<Report[]> {
 
     return res.json()
 }
+
+/**
+ * 指定されたIDの日報詳細を取得する
+ * @param id 日報ID
+ * @param accessToken API認証用のアクセストークン
+ */
+export async function getReportById(id: string, accessToken: string): Promise<Report | null> {
+    const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/api/v1/reports/${id}`, {
+        headers: {
+            Authorization: `Bearer ${accessToken}`,
+        },
+        // 毎回最新を取得
+        cache: 'no-store',
+    })
+
+    if (res.status === 404) {
+        return null
+    }
+
+    if (!res.ok) {
+        console.error(`Failed to fetch report ${id}`)
+        // エラーページへ飛ばすなどの処理も検討可能ですが、一旦nullで返す
+        return null
+    }
+
+    return res.json()
+}


### PR DESCRIPTION
- "next-themes" と "sonner" を追加
- layout.tsx に Toaster コンポーネント追加
- 新規作成: reports/[id]/page.tsx - 日報詳細ページの実装
- 新規作成: components/dashboard/ReportCopySection.tsx - 日報内容をコピーするセクションの実装
- ReportList.tsx を修正し、各レポートをクリック可能に
- 新規作成: components/ui/sonner.tsx - Sonner トースト通知の実装
- reports.ts に getReportById 関数を追加し、指定されたIDの日報詳細を取得する機能を実装

This PR fix #14 